### PR TITLE
[FEATURE] Add option to disable redirect for pages

### DIFF
--- a/Classes/Domain/Model/Action.php
+++ b/Classes/Domain/Model/Action.php
@@ -1,12 +1,13 @@
 <?php
 namespace In2code\Ipandlanguageredirect\Domain\Model;
 
+use In2code\Ipandlanguageredirect\Utility\PageUtility;
+
 /**
  * Class Action
  */
 class Action
 {
-
     /**
      * @var array
      */
@@ -18,19 +19,29 @@ class Action
     protected $referrers = [];
 
     /**
+     * @var array
+     */
+    protected $pidInRootline = [];
+
+    /**
      * @var float
      */
     protected $quantifier = 1.0;
 
     /**
      * Action constructor.
-     * @param array $events
-     * @param array $referrers
+     * @param array $configuration
      */
-    public function __construct(array $events, array $referrers)
+    public function __construct(array $configuration)
     {
-        $this->setEvents($events);
-        $this->setReferrers($referrers);
+        $this->setEvents($configuration['events']);
+
+        if (array_key_exists('referrers', $configuration)) {
+            $this->setReferrers($configuration['referrers']);
+        }
+        if (array_key_exists('pidInRootline', $configuration)) {
+            $this->setPidInRootline($configuration['pidInRootline']);
+        }
     }
 
     /**
@@ -70,6 +81,23 @@ class Action
     }
 
     /**
+     * @return array
+     */
+    public function getPidInRootline(): array
+    {
+        return $this->pidInRootline;
+    }
+
+    /**
+     * @param array $pidInRootline
+     * @return void
+     */
+    public function setPidInRootline(array $pidInRootline)
+    {
+        $this->pidInRootline = $pidInRootline;
+    }
+
+    /**
      * @return float
      */
     public function getQuantifier()
@@ -96,6 +124,15 @@ class Action
             }
             if ($multiplier > 0) {
                 $quantifier *= $multiplier;
+            }
+        }
+        $pidInRootline = $this->getPidInRootline();
+        if (!empty($pidInRootline)) {
+            foreach ($pidInRootline as $pid) {
+                if (PageUtility::isInCurrentRootline($pid)) {
+                    $quantifier = 9999;
+                    break;
+                }
             }
         }
         $this->quantifier = $quantifier;

--- a/Classes/Domain/Model/ActionSet.php
+++ b/Classes/Domain/Model/ActionSet.php
@@ -36,8 +36,7 @@ class ActionSet
         foreach ($this->rawActionsConfiguration as $actionConfiguration) {
             $action = ObjectUtility::getObjectManager()->get(
                 Action::class,
-                $actionConfiguration['events'],
-                $actionConfiguration['referrers']
+                $actionConfiguration
             );
             $this->addAction($action);
         }

--- a/Classes/Utility/PageUtility.php
+++ b/Classes/Utility/PageUtility.php
@@ -1,0 +1,42 @@
+<?php
+namespace In2code\Ipandlanguageredirect\Utility;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+
+/**
+ * Class PageUtility
+ */
+class PageUtility
+{
+    /**
+     * Checks if the given pid is the the rootline of the current page
+     *
+     * @param int $pid
+     * @return bool
+     */
+    public static function isInCurrentRootline(int $pid)
+    {
+        $tsfe = self::getTSFE();
+        $currentPageUid = $tsfe->id;
+
+        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
+        $rootline = $pageRepository->getRootLine($currentPageUid);
+
+        foreach ($rootline as $page) {
+            if ($page['uid'] === $pid) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return TypoScriptFrontendController
+     */
+    protected static function getTSFE()
+    {
+        return $GLOBALS['TSFE'];
+    }
+}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,17 @@ return [
             'events' => [
                 'suggest'
             ]
-        ]
+        ],
+        [
+            // Disable redirect for pages inside the given pid
+            'pidInRootline' => [
+                '129',
+                '11',
+            ],
+            'events' => [
+                'none',
+            ],
+        ],
     ],
     // configuration if nothing matches
     'noMatchingConfiguration' => [


### PR DESCRIPTION
Adds possibility to disable the redirect for certain pages.
Usage:

> 
    ...
    'actions' => [
        [
            // Disable redirect for pages inside the given pid
            'pidInRootline' => [
                '129',
                '11',
            ],
            'events' => [
                'none',
            ],
        ],
        ...
    ],
With this example configuration the redirect is disabled for the pages 129, 11 and all their child pages