### PR TITLE
[TASK] make sure '?key=' is added to IpApi url if ipApiKey is set

### DIFF
--- a/Classes/Utility/IpUtility.php
+++ b/Classes/Utility/IpUtility.php
@@ -63,7 +63,7 @@ class IpUtility
         $key = '';
         $keyFromConfiguration = ConfigurationUtility::getExtensionConfiguration('ipApiKey');
         if (!empty($keyFromConfiguration)) {
-            $key = $keyFromConfiguration;
+            $key = '?key=' . ltrim($keyFromConfiguration, '?key=');
         }
         return $key;
     }


### PR DESCRIPTION
When ipApiKey is added in extension manager settings, the url to ipapi should be: https://ipapi.co/ipaddress/json/?key=someapikeyfromextsettings instead of just https://ipapi.co/ipaddress/json/. It works without this commit if the part ?key= is included in extension manager settings, but with this change it will work also if the ?key= part isn't included.