### PR TITLE
[FEATURE] Set configuration path and api key via typoscript

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -23,16 +23,20 @@ class ConfigurationUtility
     /**
      * Get extension configuration from LocalConfiguration.php
      *
-     * @param string $path key or path (splitted with .)
+     * @param string $setting key or path (splitted with .)
      * @return array|string
      */
-    public static function getExtensionConfiguration($path = '')
+    public static function getExtensionConfiguration($setting = '')
     {
-        $configVariables = self::getTypo3ConfigurationVariables();
-        $configuration = unserialize($configVariables['EXT']['extConf']['ipandlanguageredirect']);
-        if (!empty($path)) {
+
+        $configurationManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager');
+        $settings = $configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS,
+            'ipandlanguageredirect',
+            'Pi1');
+
+        if (!empty($setting)) {
             try {
-                $configuration = ArrayUtility::getValueByPath($configuration, $path, '.');
+                $configuration = $settings[$setting];
             } catch (\Exception $exception) {
                 return '';
             }
@@ -53,14 +57,4 @@ class ConfigurationUtility
         return $location;
     }
 
-    /**
-     * Get extension configuration from LocalConfiguration.php
-     *
-     * @return array
-     * @SuppressWarnings(PHPMD.Superglobals)
-     */
-    protected static function getTypo3ConfigurationVariables()
-    {
-        return $GLOBALS['TYPO3_CONF_VARS'];
-    }
 }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -1,6 +1,0 @@
-plugin.tx_ipandlanguageredirect {
-	view {
-		# cat=main/file/0000; type=string; label= Path to template root (FE)
-		templateRootPath = EXT:ipandlanguageredirect/Resources/Private/Templates/
-	}
-}

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,0 +1,13 @@
+plugin.tx_ipandlanguageredirect {
+	view {
+		# cat=ipandlanguageredirect/file/0000; type=string; label= Path to template root (FE)
+		templateRootPath = EXT:ipandlanguageredirect/Resources/Private/Templates/
+	}
+	settings {
+		# cat=ipandlanguageredirect/basic/0000 type=string; label=LLL:EXT:ipandlanguageredirect/Resources/Private/Language/locallang.xlf:configuration.configurationFilePath
+		configurationFilePath = EXT:ipandlanguageredirect/Configuration/Redirect/Redirect.php
+
+		# cat=ipandlanguageredirect/basic/0010 type=text; label=LLL:EXT:ipandlanguageredirect/Resources/Private/Language/locallang.xlf:configuration.enterYourKey
+		ipApiKey =
+	}
+}

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -6,6 +6,11 @@ plugin.tx_ipandlanguageredirect {
 		}
 	}
 	features.requireCHashArgumentForActionArguments = 0
+
+	settings {
+		configurationFilePath = {$plugin.tx_ipandlanguageredirect.settings.configurationFilePath}
+		ipApiKey = {$plugin.tx_ipandlanguageredirect.settings.ipApiKey}
+	}
 }
 
 page {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,5 +1,0 @@
-# cat=basic//010; type=text; label=LLL:EXT:ipandlanguageredirect/Resources/Private/Language/locallang.xlf:configuration.configurationFilePath
-configurationFilePath = EXT:ipandlanguageredirect/Configuration/Redirect/Redirect.php
-
-# cat=basic//020; type=text; label=LLL:EXT:ipandlanguageredirect/Resources/Private/Language/locallang.xlf:configuration.enterYourKey
-ipApiKey =


### PR DESCRIPTION
Configuration and api key via typoscript for use in multi domain settings

- set new file extension for typoscript files
- add configurationFilePath to constants
- add ipApiKey to constants
- remove ext_conf_template.txt
- cleanup code removing localconfiguration settings