### PR TITLE
[BUGFIX] Do not redirect user, after he manually switches from his correct language to another website translation

### DIFF
--- a/Resources/Private/JavaScripts/Frontend.js
+++ b/Resources/Private/JavaScripts/Frontend.js
@@ -181,11 +181,17 @@ function IpandlanguageredirectFrontend() {
 	 * @param jsonObject
 	 */
 	var doAction = function(jsonObject) {
-		if (jsonObject.activated && Array.isArray(jsonObject.events)) {
+		if (Array.isArray(jsonObject.events)) {
 			// iterate through events
 			for (var key in jsonObject.events) {
-				if (jsonObject.events.hasOwnProperty(key)) {
+				if (jsonObject.activated && jsonObject.events.hasOwnProperty(key)) {
 					that[jsonObject.events[key] + 'Event'](jsonObject);
+				} else if (jsonObject.events[key] === 'redirect') {
+					/*
+					 * If a redirect is configured, but not executed for reasons, everything is ok and the redirect
+					 * should not be executed at any later time, even if user manually switches to other language.
+					 */
+					setDisableRedirectCookie();
 				}
 			}
 		}


### PR DESCRIPTION
I'm using your extension to detect browser language and redirect users to their correct website language, without showing the dialoge.

And I've detected the following misbehaviour:

* User with browser language 'xx' opens website in correct translation
* At the moment, nothing happens, not even a cookie is set
* User manually switches to other website language
* The extension cannot find a cookie and redirects him back to website langage 'xx'

In my opinion this should not happen and I created a patch to solve this: If a "redirect" is configured, the cookie is always set. Even if there is no redirect to do, because the user already visits the correct website translation.

If you accept this merge reqest, you need to minify the JavaScript yourself, because I did not know, which minifier with which settings you prefere. Or you let me know, how to do it for you.

PS: If you want to see my configuration, you can find it [in this Gist](https://gist.github.com/koehnlein/a07a96443cc9a16d15e782999667b4c1)