### PR TITLE
[BUGFIX] Correct all chines language codes from "cn" to "zh"

### DIFF
--- a/Configuration/Redirect/Redirect.php
+++ b/Configuration/Redirect/Redirect.php
@@ -73,7 +73,7 @@ return [
                     'local.domain.org'
                 ],
                 'browserLanguage' => [
-                    'cn'
+                    'zh'
                 ],
                 'countryBasedOnIp' => [
                     '*'
@@ -200,7 +200,7 @@ return [
                     'local.domain.org'
                 ],
                 'browserLanguage' => [
-                    'cn',
+                    'zh',
                 ],
                 'countryBasedOnIp' => [
                     'ae',
@@ -281,7 +281,7 @@ return [
                     'local.domain.org'
                 ],
                 'browserLanguage' => [
-                    'cn',
+                    'zh',
                 ],
                 'countryBasedOnIp' => [
                     'cn'

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ return [
                 ]
             ],
 
-            // Build URI to language 2 if browser language is chinese "cn"
+            // Build URI to language 2 if browser language is chinese "zh"
             2 => [
                 'identifier' => 'worldwide_chinese',
                 'domain' => [
@@ -161,7 +161,7 @@ return [
                     'test.domain.org'
                 ],
                 'browserLanguage' => [
-                    'cn'
+                    'zh'
                 ],
                 'countryBasedOnIp' => [
                     '*'


### PR DESCRIPTION
The correct iso code for chinese language is "zh". The iso code "cn" does not exist as valid language code. It's the correct country iso code for People's Republic of China, but not for the language.